### PR TITLE
refactor: separate client and server type generation to resolve build stru…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.4
+
+- Fixed build process that was incorrectly generating client-side types in server export paths. Server types (`@imagekit/next/server`) now correctly export only server-side functions (`getUploadAuthParams`) instead of client components.
+- Improved build configuration by separating client and server TypeScript configurations for better type isolation.
+- Cleaned up package.json scripts by removing unused `build:types` script.
+
 ## 2.1.3
 
 - Fixed missing `ref` prop support in the **Image** component. The component now properly accepts and forwards all Next.js Image props, including `ref`, by using `React.ComponentPropsWithRef<typeof NextImage>` instead of the exported `ImageProps` type.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imagekit/next",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imagekit/next",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "@imagekit/javascript": "^5.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "next": ">= 13"
+        "next": ">= 13",
+        "typescript": ">=4.7.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imagekit/next",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Next.js SDK for ImageKit.io which implements client-side upload and URL generation for use inside a next application.",
   "scripts": {
     "build:js": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@imagekit/javascript": "^5.1.0"
   },
   "peerDependencies": {
-    "next": ">= 13"
+    "next": ">= 13",
+    "typescript": ">=4.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "scripts": {
     "build:js": "rollup -c",
     "build-dev:js": "rollup -c --watch",
-    "build:types": "tsc --emitDeclarationOnly",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
-    "build": "rm -rf dist*; npm run build:types && npm run build:js"
+    "build": "rm -rf dist*; npm run build:js"
   },
   "repository": {
     "type": "git",
@@ -21,7 +20,7 @@
       "module": "./dist/client/index-esm.js"
     },
     "./server": {
-      "types": "./dist/server/types/server/index.d.ts",
+      "types": "./dist/server/types/index.d.ts",
       "main": "./dist/server/index.js",
       "module": "./dist/server/index-esm.js"
     }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,10 +8,10 @@ import pkg from "./package.json";
 
 const extensions = [".js", ".jsx", ".ts", ".tsx"];
 
-const PLUGINS = [
+const createPlugins = (tsconfigPath) => [
   peerDepsExternal(),
   resolve({ extensions }),
-  typescript({ tsconfig: "./tsconfig.json" }),
+  typescript({ tsconfig: tsconfigPath }),
   babel({
     extensions,
     babelHelpers: "bundled",
@@ -30,7 +30,7 @@ export default [
       { file: pkg.exports["."].main, format: "cjs", sourcemap: true, banner: "'use client'" },
       { file: pkg.exports["."].module, format: "es", sourcemap: true, banner: "'use client'" },
     ],
-    plugins: PLUGINS,
+    plugins: createPlugins("./tsconfig.client.json"),
   },
   // Server entry build (server-only code)
   {
@@ -39,6 +39,6 @@ export default [
       { file: pkg.exports["./server"].main, format: "cjs", sourcemap: true },
       { file: pkg.exports["./server"].module, format: "es", sourcemap: true },
     ],
-    plugins: PLUGINS,
+    plugins: createPlugins("./tsconfig.server.json"),
   },
 ];

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "declarationDir": "dist/client/types",
+    "outDir": "./dist/client"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "src/server/**/*",
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-      "declaration": true,
-      "declarationDir": "dist/types",
+      "declaration": false,
       "esModuleInterop": true,
       "outDir": "./dist",
       "jsx": "react",

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "declarationDir": "dist/server/types",
+    "outDir": "./dist/server"
+  },
+  "include": [
+    "src/server/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
Refactor: separate client and server type generation to resolve build structure issues

- Create separate tsconfig.client.json and tsconfig.server.json
- Update Rollup config to use specific TypeScript configurations for each build
- Fix package.json exports to point to correct type definitions
- Remove unused build:types script from package.json
- Simplify include/exclude patterns in TypeScript configs